### PR TITLE
Updated the readdir section to note that readdir_r is now depreacted

### DIFF
--- a/filesystems/filesystems.tex
+++ b/filesystems/filesystems.tex
@@ -215,7 +215,7 @@ if (0 == stat(newpath,&s) && S_ISDIR(s.st_mode)) dirlist(newpath)
 closedir(dirp);
 \end{lstlisting}
 
-One final note of caution: \keyword{readdir} is not thread-safe! For multi-threaded searches use \keyword{readdir\_r} which requires the caller to pass in the address of an existing dirent struct.
+One final note of caution: \keyword{readdir} is not thread-safe! Additionally \keyword{readdir\_r} is deprecated, so multi-threaded searches use \keyword{readdir} with external synchronization.
 
 See the man page of readdir for more details.
 


### PR DESCRIPTION
Citing these man pages:
http://man7.org/linux/man-pages/man3/readdir_r.3.html
http://man7.org/linux/man-pages/man3/readdir.3.html

Using readdir with synchronization over readdir_r is expressly endorsed by the man pages and I believe this should be reflected in the wikibook. This closes #31.